### PR TITLE
Add UBS test servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Liens
 
 - [ebics.org](http://www.ebics.org/)
 - [Service gratuit de test](https://software.elcimai.com/efs/accueil-qualif.jsp)
+- [Service USB gratuit de test](https://ubs-paymentstandards.ch/profile)
 - [Epics (bibliothèque en ruby)](https://github.com/railslove/epics)
 - [Module EBICS pour OpenConcerto (JAVA)](https://code.google.com/p/openconcerto/source/browse/trunk/Modules/Module+EBICS/)
 - [Un autre client EBICS en Java](http://sourceforge.net/projects/ebics/)


### PR DESCRIPTION
UBS provides some test capabilities too.

a hev test returns:

$ app/console ebics:hev
+-----------+---------------------+
| Protocole | Description         |
+-----------+---------------------+
| H004      | EBICS version 02.50 |
+-----------+---------------------+

$ cat parameters.json
{
  "url": "https://ebics.ubs-paymentstandards.ch/ebics/EbicsServlet",
  "host": "PAYTEST",
  "partner": "TESTxyz",
  "user": "000n"
}